### PR TITLE
feat: Add status label for cosmos_ibc_client_expiry metric

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -18,12 +18,16 @@ rpc:
     url: https://juno-rpc.polkachu.com:443
   - chainId: kaiyo-1
     url: https://kujira-rpc.polkachu.com:443
+  - chainId: noble-1
+    url: https://noble-rpc.polkachu.com:443
   - chainId: nois-1
     url: https://nois-rpc.polkachu.com:443
   - chainId: osmo-test-5
     url: https://rpc.osmotest5.osmosis.zone:443
   - chainId: osmosis-1
     url: https://osmosis-rpc.stakely.io:443
+  - chainId: sandbox-01
+    url: https://rpc.sandbox-01.aksh.pw:443
   - chainId: theta-testnet-001
     url: https://rpc.sentry-01.theta-testnet.polypore.xyz:443
   - chainId: umee-1

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	cosmossdk.io/math v1.0.1
 	github.com/caarlos0/env/v9 v9.0.0
 	github.com/cosmos/relayer/v2 v2.4.1
-	github.com/google/go-cmp v0.5.9
 	github.com/google/go-github/v55 v55.0.0
 	github.com/prometheus/client_golang v1.15.0
 	github.com/stretchr/testify v1.8.4
@@ -87,6 +86,7 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/btree v1.1.2 // indirect
+	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/orderedcode v0.0.1 // indirect
 	github.com/google/s2a-go v0.1.4 // indirect

--- a/pkg/account/account.go
+++ b/pkg/account/account.go
@@ -8,17 +8,11 @@ import (
 	"github.com/archway-network/relayer_exporter/pkg/chain"
 )
 
-const (
-	successStatus = "success"
-	errorStatus   = "error"
-)
-
 type Account struct {
 	Address string `yaml:"address"`
 	Denom   string `yaml:"denom"`
 	ChainID string `yaml:"chainId"`
 	Balance math.Int
-	Status  string
 }
 
 func (a *Account) GetBalance(rpcs map[string]string) error {
@@ -34,13 +28,10 @@ func (a *Account) GetBalance(rpcs map[string]string) error {
 
 	coins, err := chain.ChainProvider.QueryBalanceWithAddress(ctx, a.Address)
 	if err != nil {
-		a.Status = errorStatus
-
 		return err
 	}
 
 	a.Balance = coins.AmountOf(a.Denom)
-	a.Status = successStatus
 
 	return nil
 }

--- a/pkg/ibc/ibc.go
+++ b/pkg/ibc/ibc.go
@@ -6,9 +6,7 @@ import (
 	"time"
 
 	"github.com/archway-network/relayer_exporter/pkg/chain"
-	log "github.com/archway-network/relayer_exporter/pkg/logger"
 	"github.com/cosmos/relayer/v2/relayer"
-	"github.com/google/go-cmp/cmp"
 )
 
 type ClientsInfo struct {
@@ -18,38 +16,6 @@ type ClientsInfo struct {
 	ChainB                 *relayer.Chain
 	ChainBClientInfo       relayer.ClientStateInfo
 	ChainBClientExpiration time.Time
-}
-
-func GetClientsInfos(ibcs []*relayer.IBCdata, rpcs map[string]string) []ClientsInfo {
-	num := len(ibcs)
-
-	out := make(chan ClientsInfo, num)
-	defer close(out)
-
-	for i := 0; i < num; i++ {
-		go func(i int) {
-			clientsInfo, err := GetClientsInfo(ibcs[i], rpcs)
-			if err != nil {
-				out <- ClientsInfo{}
-
-				log.Error(err.Error())
-
-				return
-			}
-			out <- clientsInfo
-		}(i)
-	}
-
-	clientsInfos := []ClientsInfo{}
-
-	for i := 0; i < num; i++ {
-		ci := <-out
-		if !cmp.Equal(ci, ClientsInfo{}) {
-			clientsInfos = append(clientsInfos, ci)
-		}
-	}
-
-	return clientsInfos
 }
 
 func GetClientsInfo(ibc *relayer.IBCdata, rpcs map[string]string) (ClientsInfo, error) {


### PR DESCRIPTION
It allows to detect a situation when there are errors accessing RPCs endpoints for some ibc path. 
Perviously `cosmos_ibc_client_expiry` wasn't published in such case. With this PR it will be published with `status` label equal `error`.