### PR TITLE
feat: Use separate dir for testnets IBC paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ github:
   org: archway-network
   repo: networks
   dir: _IBC
+  testnetsDir: testnets/_IBC
 
 accounts:
   - address: archway1l2al7y78500h5akvgt8exwnkpmf2zmk8ky9ht3

--- a/config.yaml
+++ b/config.yaml
@@ -51,11 +51,21 @@ rpc:
   - chainName: umee
     chainId: umee-1
     url: https://rpc-umee.mzonder.com:443
+  - chainName: gravitybridge
+    chainId: gravity-bridge-3
+    url: https://gravitychain.io:26657
+  - chainName: omniflixhub
+    chainId: omniflixhub-1
+    url: https://rpc-omniflix.mzonder.com:443
+  - chainName: decentr
+    chainId: mainnet-3
+    url: https://poseidon.mainnet.decentr.xyz:443
 
 github:
   org: archway-network
   repo: networks
   dir: _IBC
+  testnetsDir: testnets/_IBC
 
 accounts:
   - address: archway1l2al7y78500h5akvgt8exwnkpmf2zmk8ky9ht3

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,4 +39,19 @@ func TestGetRPCsMap(t *testing.T) {
 	res := cfg.GetRPCsMap()
 
 	assert.Equal(t, &exp, res)
+}
+
+func TestGetPaths(t *testing.T) {
+	cfg := Config{}
+
+	expError := ErrGitHubClient
+
+	_, err := cfg.getPaths("_IBC", nil)
+	if err == nil {
+		t.Fatalf("Expected error %q, got no error", expError)
+	}
+
+	if !errors.Is(err, expError) {
+		t.Errorf("Expected error %q, got %q", expError, err)
+	}
 }


### PR DESCRIPTION
After changing networks repo structure https://github.com/archway-network/networks/pull/212 IBC paths for testnets aren't monitored. This PR adds a feature to include extra dir with IBC paths for testnets to monitor them.