### PR TITLE
feat: new export for stuck packets

### DIFF
--- a/cmd/relayer_exporter/relayer_exporter.go
+++ b/cmd/relayer_exporter/relayer_exporter.go
@@ -6,11 +6,12 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
 	"github.com/archway-network/relayer_exporter/pkg/collector"
 	"github.com/archway-network/relayer_exporter/pkg/config"
 	log "github.com/archway-network/relayer_exporter/pkg/logger"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 var (
@@ -42,7 +43,14 @@ func main() {
 		log.Fatal(err.Error())
 	}
 
-	log.Info(fmt.Sprintf("Getting IBC paths from %s/%s/%s on GitHub", cfg.GitHub.Org, cfg.GitHub.Repo, cfg.GitHub.IBCDir))
+	log.Info(
+		fmt.Sprintf(
+			"Getting IBC paths from %s/%s/%s on GitHub",
+			cfg.GitHub.Org,
+			cfg.GitHub.Repo,
+			cfg.GitHub.IBCDir,
+		),
+	)
 
 	// TODO: Add a feature to refresh paths at configured interval
 	paths, err := cfg.IBCPaths()
@@ -52,7 +60,7 @@ func main() {
 
 	rpcs := cfg.GetRPCsMap()
 
-	clientsCollector := collector.IBCClientsCollector{
+	ibcCollector := collector.IBCCollector{
 		RPCs:  rpcs,
 		Paths: paths,
 	}
@@ -62,7 +70,7 @@ func main() {
 		Accounts: cfg.Accounts,
 	}
 
-	prometheus.MustRegister(clientsCollector)
+	prometheus.MustRegister(ibcCollector)
 	prometheus.MustRegister(balancesCollector)
 
 	http.Handle("/metrics", promhttp.Handler())

--- a/config.yaml
+++ b/config.yaml
@@ -35,7 +35,7 @@ rpc:
     url: https://noble-rpc.polkachu.com:443
   - chainName: nois
     chainId: nois-1
-    url: https://rpc.cosmos.directory/nois:443
+    url: https://nois.rpc.kjnodes.com:443
   - chainName: osmosistestnet
     chainId: osmo-test-5
     url: https://rpc.osmotest5.osmosis.zone:443

--- a/pkg/chain/chain.go
+++ b/pkg/chain/chain.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cosmos/relayer/v2/relayer"
 	"github.com/cosmos/relayer/v2/relayer/chains/cosmos"
+	"go.uber.org/zap"
 )
 
 const (
@@ -19,7 +20,7 @@ type Info struct {
 }
 
 func PrepChain(info Info) (*relayer.Chain, error) {
-	chain := relayer.Chain{}
+	logger := zap.NewNop()
 	providerConfig := cosmos.CosmosProviderConfig{
 		ChainID:        info.ChainID,
 		Timeout:        rpcTimeout,
@@ -37,12 +38,12 @@ func PrepChain(info Info) (*relayer.Chain, error) {
 		return nil, err
 	}
 
-	chain.ChainProvider = provider
+	chain := relayer.NewChain(logger, provider, false)
 
 	err = chain.SetPath(&relayer.PathEnd{ClientID: info.ClientID})
 	if err != nil {
 		return nil, err
 	}
 
-	return &chain, nil
+	return chain, nil
 }

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -3,6 +3,7 @@ package collector
 import (
 	"fmt"
 	"math/big"
+	"reflect"
 	"sync"
 
 	"github.com/cosmos/relayer/v2/relayer"
@@ -132,49 +133,50 @@ func (cc IBCCollector) Collect(ch chan<- prometheus.Metric) {
 			if err != nil {
 				status = errorStatus
 
-				fmt.Println("FOOOOBAAAAR")
 				log.Error(err.Error())
 			}
 
-			for _, sp := range stuckPackets.Channels {
-				ch <- prometheus.MustNewConstMetric(
-					channelStuckPackets,
-					prometheus.GaugeValue,
-					float64(sp.StuckPackets.Total),
-					[]string{
-						sp.Source,
-						sp.Destination,
-						(*cc.RPCs)[path.Chain1.ChainName].ChainID,
-						(*cc.RPCs)[path.Chain2.ChainName].ChainID,
-						status,
-					}...,
-				)
+			if !reflect.DeepEqual(stuckPackets, ibc.ChannelsInfo{}) {
+				for _, sp := range stuckPackets.Channels {
+					ch <- prometheus.MustNewConstMetric(
+						channelStuckPackets,
+						prometheus.GaugeValue,
+						float64(sp.StuckPackets.Total),
+						[]string{
+							sp.Source,
+							sp.Destination,
+							(*cc.RPCs)[path.Chain1.ChainName].ChainID,
+							(*cc.RPCs)[path.Chain2.ChainName].ChainID,
+							status,
+						}...,
+					)
 
-				ch <- prometheus.MustNewConstMetric(
-					channelSrcStuckPackets,
-					prometheus.GaugeValue,
-					float64(sp.StuckPackets.Source),
-					[]string{
-						sp.Source,
-						sp.Destination,
-						(*cc.RPCs)[path.Chain1.ChainName].ChainID,
-						(*cc.RPCs)[path.Chain2.ChainName].ChainID,
-						status,
-					}...,
-				)
+					ch <- prometheus.MustNewConstMetric(
+						channelSrcStuckPackets,
+						prometheus.GaugeValue,
+						float64(sp.StuckPackets.Source),
+						[]string{
+							sp.Source,
+							sp.Destination,
+							(*cc.RPCs)[path.Chain1.ChainName].ChainID,
+							(*cc.RPCs)[path.Chain2.ChainName].ChainID,
+							status,
+						}...,
+					)
 
-				ch <- prometheus.MustNewConstMetric(
-					channelDstStuckPackets,
-					prometheus.GaugeValue,
-					float64(sp.StuckPackets.Destination),
-					[]string{
-						sp.Source,
-						sp.Destination,
-						(*cc.RPCs)[path.Chain1.ChainName].ChainID,
-						(*cc.RPCs)[path.Chain2.ChainName].ChainID,
-						status,
-					}...,
-				)
+					ch <- prometheus.MustNewConstMetric(
+						channelDstStuckPackets,
+						prometheus.GaugeValue,
+						float64(sp.StuckPackets.Destination),
+						[]string{
+							sp.Source,
+							sp.Destination,
+							(*cc.RPCs)[path.Chain1.ChainName].ChainID,
+							(*cc.RPCs)[path.Chain2.ChainName].ChainID,
+							status,
+						}...,
+					)
+				}
 			}
 		}(p)
 	}

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -80,6 +80,7 @@ func (cc IBCCollector) Collect(ch chan<- prometheus.Metric) {
 		go func(path *relayer.IBCdata) {
 			defer wg.Done()
 
+			// Client info
 			ci, err := ibc.GetClientsInfo(path, cc.RPCs)
 			status := successStatus
 
@@ -102,6 +103,9 @@ func (cc IBCCollector) Collect(ch chan<- prometheus.Metric) {
 				float64(ci.ChainBClientExpiration.Unix()),
 				[]string{(*cc.RPCs)[path.Chain2.ChainName].ChainID, path.Chain2.ClientID, (*cc.RPCs)[path.Chain1.ChainName].ChainID, status}...,
 			)
+
+			// Stuck packets
+			status = successStatus
 
 			stuckPackets, err := ibc.GetChannelsInfo(path, cc.RPCs)
 			if err != nil {

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -34,7 +34,8 @@ var (
 		channelStuckPacketsMetricName,
 		"Returns stuck packets for a channel.",
 		[]string{
-			"channel_id",
+			"src_channel_id",
+			"dst_channel_id",
 			"src_chain_id",
 			"dst_chain_id",
 			"status",
@@ -45,7 +46,8 @@ var (
 		channelSrcStuckPacketsMetricName,
 		"Returns source stuck packets for a channel.",
 		[]string{
-			"channel_id",
+			"src_channel_id",
+			"dst_channel_id",
 			"src_chain_id",
 			"dst_chain_id",
 			"status",
@@ -56,7 +58,8 @@ var (
 		channelDstStuckPacketsMetricName,
 		"Returns destination stuck packets for a channel.",
 		[]string{
-			"channel_id",
+			"src_channel_id",
+			"dst_channel_id",
 			"src_chain_id",
 			"dst_chain_id",
 			"status",
@@ -129,6 +132,7 @@ func (cc IBCCollector) Collect(ch chan<- prometheus.Metric) {
 			if err != nil {
 				status = errorStatus
 
+				fmt.Println("FOOOOBAAAAR")
 				log.Error(err.Error())
 			}
 
@@ -138,7 +142,8 @@ func (cc IBCCollector) Collect(ch chan<- prometheus.Metric) {
 					prometheus.GaugeValue,
 					float64(sp.StuckPackets.Total),
 					[]string{
-						sp.Name,
+						sp.Source,
+						sp.Destination,
 						(*cc.RPCs)[path.Chain1.ChainName].ChainID,
 						(*cc.RPCs)[path.Chain2.ChainName].ChainID,
 						status,
@@ -150,7 +155,8 @@ func (cc IBCCollector) Collect(ch chan<- prometheus.Metric) {
 					prometheus.GaugeValue,
 					float64(sp.StuckPackets.Source),
 					[]string{
-						sp.Name,
+						sp.Source,
+						sp.Destination,
 						(*cc.RPCs)[path.Chain1.ChainName].ChainID,
 						(*cc.RPCs)[path.Chain2.ChainName].ChainID,
 						status,
@@ -162,7 +168,8 @@ func (cc IBCCollector) Collect(ch chan<- prometheus.Metric) {
 					prometheus.GaugeValue,
 					float64(sp.StuckPackets.Destination),
 					[]string{
-						sp.Name,
+						sp.Source,
+						sp.Destination,
 						(*cc.RPCs)[path.Chain1.ChainName].ChainID,
 						(*cc.RPCs)[path.Chain2.ChainName].ChainID,
 						status,

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -111,6 +111,20 @@ func (cc IBCCollector) Collect(ch chan<- prometheus.Metric) {
 				log.Error(err.Error())
 			}
 
+			ch <- prometheus.MustNewConstMetric(
+				clientExpiry,
+				prometheus.GaugeValue,
+				float64(ci.ChainAClientExpiration.Unix()),
+				[]string{(*cc.RPCs)[path.Chain1.ChainName].ChainID, path.Chain1.ClientID, (*cc.RPCs)[path.Chain2.ChainName].ChainID, status}...,
+			)
+
+			ch <- prometheus.MustNewConstMetric(
+				clientExpiry,
+				prometheus.GaugeValue,
+				float64(ci.ChainBClientExpiration.Unix()),
+				[]string{(*cc.RPCs)[path.Chain2.ChainName].ChainID, path.Chain2.ClientID, (*cc.RPCs)[path.Chain1.ChainName].ChainID, status}...,
+			)
+
 			stuckPackets, err := ibc.GetChannelInfo(path, cc.RPCs)
 			if err != nil {
 				status = errorStatus
@@ -155,20 +169,6 @@ func (cc IBCCollector) Collect(ch chan<- prometheus.Metric) {
 					}...,
 				)
 			}
-
-			ch <- prometheus.MustNewConstMetric(
-				clientExpiry,
-				prometheus.GaugeValue,
-				float64(ci.ChainAClientExpiration.Unix()),
-				[]string{(*cc.RPCs)[path.Chain1.ChainName].ChainID, path.Chain1.ClientID, (*cc.RPCs)[path.Chain2.ChainName].ChainID, status}...,
-			)
-
-			ch <- prometheus.MustNewConstMetric(
-				clientExpiry,
-				prometheus.GaugeValue,
-				float64(ci.ChainBClientExpiration.Unix()),
-				[]string{(*cc.RPCs)[path.Chain2.ChainName].ChainID, path.Chain2.ClientID, (*cc.RPCs)[path.Chain1.ChainName].ChainID, status}...,
-			)
 		}(p)
 	}
 

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -125,7 +125,7 @@ func (cc IBCCollector) Collect(ch chan<- prometheus.Metric) {
 				[]string{(*cc.RPCs)[path.Chain2.ChainName].ChainID, path.Chain2.ClientID, (*cc.RPCs)[path.Chain1.ChainName].ChainID, status}...,
 			)
 
-			stuckPackets, err := ibc.GetChannelInfo(path, cc.RPCs)
+			stuckPackets, err := ibc.GetChannelsInfo(path, cc.RPCs)
 			if err != nil {
 				status = errorStatus
 

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -16,13 +16,11 @@ import (
 )
 
 const (
-	successStatus                    = "success"
-	errorStatus                      = "error"
-	clientExpiryMetricName           = "cosmos_ibc_client_expiry"
-	walletBalanceMetricName          = "cosmos_wallet_balance"
-	channelStuckPacketsMetricName    = "cosmos_ibc_stuck_packets_total"
-	channelSrcStuckPacketsMetricName = "cosmos_ibc_stuck_packets_src"
-	channelDstStuckPacketsMetricName = "cosmos_ibc_stuck_packets_dst"
+	successStatus                 = "success"
+	errorStatus                   = "error"
+	clientExpiryMetricName        = "cosmos_ibc_client_expiry"
+	walletBalanceMetricName       = "cosmos_wallet_balance"
+	channelStuckPacketsMetricName = "cosmos_ibc_stuck_packets"
 )
 
 var (
@@ -34,30 +32,6 @@ var (
 	channelStuckPackets = prometheus.NewDesc(
 		channelStuckPacketsMetricName,
 		"Returns stuck packets for a channel.",
-		[]string{
-			"src_channel_id",
-			"dst_channel_id",
-			"src_chain_id",
-			"dst_chain_id",
-			"status",
-		},
-		nil,
-	)
-	channelSrcStuckPackets = prometheus.NewDesc(
-		channelSrcStuckPacketsMetricName,
-		"Returns source stuck packets for a channel.",
-		[]string{
-			"src_channel_id",
-			"dst_channel_id",
-			"src_chain_id",
-			"dst_chain_id",
-			"status",
-		},
-		nil,
-	)
-	channelDstStuckPackets = prometheus.NewDesc(
-		channelDstStuckPacketsMetricName,
-		"Returns destination stuck packets for a channel.",
 		[]string{
 			"src_channel_id",
 			"dst_channel_id",
@@ -141,19 +115,6 @@ func (cc IBCCollector) Collect(ch chan<- prometheus.Metric) {
 					ch <- prometheus.MustNewConstMetric(
 						channelStuckPackets,
 						prometheus.GaugeValue,
-						float64(sp.StuckPackets.Total),
-						[]string{
-							sp.Source,
-							sp.Destination,
-							(*cc.RPCs)[path.Chain1.ChainName].ChainID,
-							(*cc.RPCs)[path.Chain2.ChainName].ChainID,
-							status,
-						}...,
-					)
-
-					ch <- prometheus.MustNewConstMetric(
-						channelSrcStuckPackets,
-						prometheus.GaugeValue,
 						float64(sp.StuckPackets.Source),
 						[]string{
 							sp.Source,
@@ -165,14 +126,14 @@ func (cc IBCCollector) Collect(ch chan<- prometheus.Metric) {
 					)
 
 					ch <- prometheus.MustNewConstMetric(
-						channelDstStuckPackets,
+						channelStuckPackets,
 						prometheus.GaugeValue,
 						float64(sp.StuckPackets.Destination),
 						[]string{
-							sp.Source,
 							sp.Destination,
-							(*cc.RPCs)[path.Chain1.ChainName].ChainID,
+							sp.Source,
 							(*cc.RPCs)[path.Chain2.ChainName].ChainID,
+							(*cc.RPCs)[path.Chain1.ChainName].ChainID,
 							status,
 						}...,
 					)

--- a/pkg/ibc/ibc.go
+++ b/pkg/ibc/ibc.go
@@ -12,6 +12,8 @@ import (
 	"github.com/archway-network/relayer_exporter/pkg/config"
 )
 
+const stateOpen = 3
+
 type ClientsInfo struct {
 	ChainA                 *relayer.Chain
 	ChainAClientInfo       relayer.ClientStateInfo
@@ -135,7 +137,7 @@ func GetChannelInfo(ibc *relayer.IBCdata, rpcs *map[string]config.RPC) (Channels
 		}
 
 		ch := chantypes.IdentifiedChannel{
-			State:    3,
+			State:    stateOpen,
 			Ordering: order,
 			Counterparty: chantypes.Counterparty{
 				PortId:    c.Chain2.PortID,

--- a/pkg/ibc/ibc.go
+++ b/pkg/ibc/ibc.go
@@ -121,6 +121,13 @@ func GetChannelsInfo(ibc *relayer.IBCdata, rpcs *map[string]config.RPC) (Channel
 		return ChannelsInfo{}, fmt.Errorf("Error: %w for %v", err, cdB)
 	}
 
+	// test that RPC endpoints are working
+	if _, _, err := relayer.QueryLatestHeights(
+		ctx, chainA, chainB,
+	); err != nil {
+		return ChannelsInfo{}, fmt.Errorf("Error: %w for %v", err, cdA)
+	}
+
 	for _, c := range ibc.Channels {
 		var order chantypes.Order
 

--- a/pkg/ibc/ibc.go
+++ b/pkg/ibc/ibc.go
@@ -135,13 +135,6 @@ func GetChannelsInfo(ibc *relayer.IBCdata, rpcs *map[string]config.RPC) (Channel
 		return ChannelsInfo{}, fmt.Errorf("Error: %w for %v", err, cdB)
 	}
 
-	// test that RPC endpoints are working
-	if _, _, err := relayer.QueryLatestHeights(
-		ctx, chainA, chainB,
-	); err != nil {
-		return channelInfo, fmt.Errorf("Error: %w for %v", err, cdA)
-	}
-
 	for i, c := range channelInfo.Channels {
 		var order chantypes.Order
 

--- a/pkg/ibc/ibc.go
+++ b/pkg/ibc/ibc.go
@@ -90,6 +90,12 @@ func GetChannelInfo(ibc *relayer.IBCdata, rpcs *map[string]config.RPC) (Channels
 	ctx := context.Background()
 	channelInfo := ChannelsInfo{}
 
+	if (*rpcs)[ibc.Chain1.ChainName].ChainID == "" || (*rpcs)[ibc.Chain2.ChainName].ChainID == "" {
+		return ChannelsInfo{}, fmt.Errorf(
+			"Error: RPC data is missing, cannot retrieve channel data",
+		)
+	}
+
 	cdA := chain.Info{
 		ChainID:  (*rpcs)[ibc.Chain1.ChainName].ChainID,
 		RPCAddr:  (*rpcs)[ibc.Chain1.ChainName].URL,

--- a/pkg/ibc/ibc.go
+++ b/pkg/ibc/ibc.go
@@ -28,7 +28,8 @@ type ChannelsInfo struct {
 }
 
 type Channel struct {
-	Name         string
+	Source       string
+	Destination  string
 	StuckPackets struct {
 		Source      int
 		Destination int
@@ -133,7 +134,8 @@ func GetChannelsInfo(ibc *relayer.IBCdata, rpcs *map[string]config.RPC) (Channel
 
 		var channel Channel
 
-		channel.Name = c.Chain1.ChannelID
+		channel.Source = c.Chain1.ChannelID
+		channel.Destination = c.Chain2.ChannelID
 
 		switch c.Ordering {
 		case "none":

--- a/pkg/ibc/ibc.go
+++ b/pkg/ibc/ibc.go
@@ -24,6 +24,8 @@ type ClientsInfo struct {
 }
 
 type ChannelsInfo struct {
+	ChainA   *relayer.Chain
+	ChainB   *relayer.Chain
 	Channels []Channel
 }
 
@@ -126,7 +128,14 @@ func GetChannelsInfo(ibc *relayer.IBCdata, rpcs *map[string]config.RPC) (Channel
 	if _, _, err := relayer.QueryLatestHeights(
 		ctx, chainA, chainB,
 	); err != nil {
-		return ChannelsInfo{}, fmt.Errorf("Error: %w for %v", err, cdA)
+		for _, c := range ibc.Channels {
+			var channel Channel
+			channel.Source = c.Chain1.ChannelID
+			channel.Destination = c.Chain2.ChannelID
+			channelInfo.Channels = append(channelInfo.Channels, channel)
+		}
+
+		return channelInfo, fmt.Errorf("Error: %w for %v", err, cdA)
 	}
 
 	for _, c := range ibc.Channels {

--- a/pkg/ibc/ibc.go
+++ b/pkg/ibc/ibc.go
@@ -88,7 +88,7 @@ func GetClientsInfo(ibc *relayer.IBCdata, rpcs *map[string]config.RPC) (ClientsI
 	return clientsInfo, nil
 }
 
-func GetChannelInfo(ibc *relayer.IBCdata, rpcs *map[string]config.RPC) (ChannelsInfo, error) {
+func GetChannelsInfo(ibc *relayer.IBCdata, rpcs *map[string]config.RPC) (ChannelsInfo, error) {
 	ctx := context.Background()
 	channelInfo := ChannelsInfo{}
 

--- a/pkg/ibc/ibc.go
+++ b/pkg/ibc/ibc.go
@@ -94,7 +94,8 @@ func GetChannelsInfo(ibc *relayer.IBCdata, rpcs *map[string]config.RPC) (Channel
 
 	if (*rpcs)[ibc.Chain1.ChainName].ChainID == "" || (*rpcs)[ibc.Chain2.ChainName].ChainID == "" {
 		return ChannelsInfo{}, fmt.Errorf(
-			"Error: RPC data is missing, cannot retrieve channel data",
+			"Error: RPC data is missing, cannot retrieve channel data: %v",
+			ibc.Channels,
 		)
 	}
 

--- a/pkg/ibc/ibc.go
+++ b/pkg/ibc/ibc.go
@@ -135,6 +135,13 @@ func GetChannelsInfo(ibc *relayer.IBCdata, rpcs *map[string]config.RPC) (Channel
 		return ChannelsInfo{}, fmt.Errorf("Error: %w for %v", err, cdB)
 	}
 
+	// test that RPC endpoints are working
+	if _, _, err := relayer.QueryLatestHeights(
+		ctx, chainA, chainB,
+	); err != nil {
+		return channelInfo, fmt.Errorf("Error: %w for %v", err, cdA)
+	}
+
 	for i, c := range channelInfo.Channels {
 		var order chantypes.Order
 

--- a/pkg/ibc/ibc.go
+++ b/pkg/ibc/ibc.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"time"
 
+	chantypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
+	"github.com/cosmos/relayer/v2/relayer"
+
 	"github.com/archway-network/relayer_exporter/pkg/chain"
 	"github.com/archway-network/relayer_exporter/pkg/config"
-	"github.com/cosmos/relayer/v2/relayer"
 )
 
 type ClientsInfo struct {
@@ -17,6 +19,13 @@ type ClientsInfo struct {
 	ChainB                 *relayer.Chain
 	ChainBClientInfo       relayer.ClientStateInfo
 	ChainBClientExpiration time.Time
+}
+
+type ChannelInfo struct {
+	StuckPackets struct {
+		Source      int
+		Destination int
+	}
 }
 
 func GetClientsInfo(ibc *relayer.IBCdata, rpcs *map[string]config.RPC) (ClientsInfo, error) {
@@ -50,15 +59,80 @@ func GetClientsInfo(ibc *relayer.IBCdata, rpcs *map[string]config.RPC) (ClientsI
 
 	ctx := context.Background()
 
-	clientsInfo.ChainAClientExpiration, clientsInfo.ChainAClientInfo, err = relayer.QueryClientExpiration(ctx, chainA, chainB)
+	clientsInfo.ChainAClientExpiration, clientsInfo.ChainAClientInfo, err = relayer.QueryClientExpiration(
+		ctx,
+		chainA,
+		chainB,
+	)
 	if err != nil {
 		return ClientsInfo{}, fmt.Errorf("Error: %w path %v <-> %v", err, cdA, cdB)
 	}
 
-	clientsInfo.ChainBClientExpiration, clientsInfo.ChainBClientInfo, err = relayer.QueryClientExpiration(ctx, chainB, chainA)
+	clientsInfo.ChainBClientExpiration, clientsInfo.ChainBClientInfo, err = relayer.QueryClientExpiration(
+		ctx,
+		chainB,
+		chainA,
+	)
 	if err != nil {
 		return ClientsInfo{}, fmt.Errorf("Error: %w path %v <-> %v", err, cdB, cdA)
 	}
 
 	return clientsInfo, nil
+}
+
+func GetChannelInfo(ibc *relayer.IBCdata, rpcs *map[string]config.RPC) (ChannelInfo, error) {
+	ctx := context.Background()
+	channelInfo := ChannelInfo{}
+
+	cdA := chain.Info{
+		ChainID:  (*rpcs)[ibc.Chain1.ChainName].ChainID,
+		RPCAddr:  (*rpcs)[ibc.Chain1.ChainName].URL,
+		ClientID: ibc.Chain1.ClientID,
+	}
+
+	chainA, err := chain.PrepChain(cdA)
+	if err != nil {
+		return ChannelInfo{}, fmt.Errorf("Error: %w for %v", err, cdA)
+	}
+
+	cdB := chain.Info{
+		ChainID:  (*rpcs)[ibc.Chain2.ChainName].ChainID,
+		RPCAddr:  (*rpcs)[ibc.Chain2.ChainName].URL,
+		ClientID: ibc.Chain2.ClientID,
+	}
+
+	chainB, err := chain.PrepChain(cdB)
+	if err != nil {
+		return ChannelInfo{}, fmt.Errorf("Error: %w for %v", err, cdB)
+	}
+
+	for _, c := range ibc.Channels {
+		var order chantypes.Order
+
+		switch c.Ordering {
+		case "none":
+			order = chantypes.NONE
+		case "unordered":
+			order = chantypes.UNORDERED
+		case "ordered":
+			order = chantypes.ORDERED
+		}
+
+		channel := chantypes.IdentifiedChannel{
+			State:    3,
+			Ordering: order,
+			Counterparty: chantypes.Counterparty{
+				PortId:    c.Chain2.PortID,
+				ChannelId: c.Chain2.ChannelID,
+			},
+			PortId:    c.Chain1.PortID,
+			ChannelId: c.Chain2.ChannelID,
+		}
+
+		unrelayedSequences := relayer.UnrelayedSequences(ctx, chainA, chainB, &channel)
+		channelInfo.StuckPackets.Source += len(unrelayedSequences.Src)
+		channelInfo.StuckPackets.Destination += len(unrelayedSequences.Dst)
+	}
+
+	return channelInfo, nil
 }


### PR DESCRIPTION
This PR will add new IBC export for IBC channel which will include stuck/pending packets metric.
Also renaming/combining  `IBCClientsCollector` to `IBCCollector` to use only one collector for all IBC related metrics.