### PR TITLE
feat: add discord labels to metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	cosmossdk.io/math v1.0.1
 	github.com/caarlos0/env/v9 v9.0.0
+	github.com/cosmos/ibc-go/v7 v7.2.0
 	github.com/cosmos/relayer/v2 v2.4.1
 	github.com/google/go-github/v55 v55.0.0
 	github.com/prometheus/client_golang v1.15.0
@@ -56,7 +57,6 @@ require (
 	github.com/cosmos/gogogateway v1.2.0 // indirect
 	github.com/cosmos/gogoproto v1.4.10 // indirect
 	github.com/cosmos/iavl v0.20.0 // indirect
-	github.com/cosmos/ibc-go/v7 v7.2.0 // indirect
 	github.com/cosmos/ics23/go v0.10.0 // indirect
 	github.com/cosmos/ledger-cosmos-go v0.12.2 // indirect
 	github.com/cosmos/rosetta-sdk-go v0.10.0 // indirect

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -220,9 +220,10 @@ func (wb WalletBalanceCollector) Collect(ch chan<- prometheus.Metric) {
 
 func getDiscordIDs(ops []config.Operator) string {
 	var ids []string
-	for _, op := range ops {
 
-		pattern := regexp.MustCompile(`^\d+$`)
+	pattern := regexp.MustCompile(`^\d+$`)
+
+	for _, op := range ops {
 		if pattern.MatchString(op.Discord.ID) {
 			ids = append(ids, op.Discord.ID)
 		}

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 	"reflect"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -220,7 +221,11 @@ func (wb WalletBalanceCollector) Collect(ch chan<- prometheus.Metric) {
 func getDiscordIDs(ops []config.Operator) string {
 	var ids []string
 	for _, op := range ops {
-		ids = append(ids, op.Discord.ID)
+
+		pattern := regexp.MustCompile(`^\d+$`)
+		if pattern.MatchString(op.Discord.ID) {
+			ids = append(ids, op.Discord.ID)
+		}
 	}
 
 	return strings.Join(ids, ",")

--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -56,7 +56,9 @@ func TestDiscordIDs(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		res := getDiscordIDs(tc.ops)
-		assert.Equal(t, tc.expected, res)
+		t.Run(tc.name, func(t *testing.T) {
+			res := getDiscordIDs(tc.ops)
+			assert.Equal(t, tc.expected, res)
+		})
 	}
 }

--- a/pkg/collector/collector_test.go
+++ b/pkg/collector/collector_test.go
@@ -1,0 +1,62 @@
+package collector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/archway-network/relayer_exporter/pkg/config"
+)
+
+func TestDiscordIDs(t *testing.T) {
+	testCases := []struct {
+		name     string
+		ops      []config.Operator
+		expected string
+	}{
+		{
+			name: "All Valid IDs",
+			ops: []config.Operator{
+				{
+					Discord: config.Discord{ID: "123456"},
+				},
+				{
+					Discord: config.Discord{ID: "12312387"},
+				},
+			},
+			expected: "123456,12312387",
+		},
+		{
+			name: "Some Invalid IDs",
+			ops: []config.Operator{
+				{
+					Discord: config.Discord{ID: "123456"},
+				},
+				{
+					Discord: config.Discord{ID: "ABCDEF"},
+				},
+				{
+					Discord: config.Discord{ID: "789012"},
+				},
+			},
+			expected: "123456,789012",
+		},
+		{
+			name: "No Valid IDs",
+			ops: []config.Operator{
+				{Discord: config.Discord{ID: "ABCDEF"}},
+				{Discord: config.Discord{ID: "GHIJKL"}},
+			},
+			expected: "",
+		},
+		{
+			name:     "Empty Input",
+			ops:      []config.Operator{{}, {}, {}},
+			expected: "",
+		},
+	}
+	for _, tc := range testCases {
+		res := getDiscordIDs(tc.ops)
+		assert.Equal(t, tc.expected, res)
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -85,12 +85,14 @@ type Operator struct {
 	Chain2 struct {
 		Address string `json:"address"`
 	} `json:"chain_2"`
-	Memo    string `json:"memo"`
-	Name    string `json:"name"`
-	Discord struct {
-		Handle string `json:"handle"`
-		ID     string `json:"id"`
-	} `json:"discord"`
+	Memo    string  `json:"memo"`
+	Name    string  `json:"name"`
+	Discord Discord `json:"discord"`
+}
+
+type Discord struct {
+	Handle string `json:"handle"`
+	ID     string `json:"id"`
 }
 
 func (a *Account) GetBalance(rpcs *map[string]RPC) error {

--- a/pkg/ibc/ibc.go
+++ b/pkg/ibc/ibc.go
@@ -39,7 +39,7 @@ type Channel struct {
 	}
 }
 
-func GetClientsInfo(ibc *relayer.IBCdata, rpcs *map[string]config.RPC) (ClientsInfo, error) {
+func GetClientsInfo(ibc *config.IBCData, rpcs *map[string]config.RPC) (ClientsInfo, error) {
 	clientsInfo := ClientsInfo{}
 
 	cdA := chain.Info{
@@ -91,7 +91,7 @@ func GetClientsInfo(ibc *relayer.IBCdata, rpcs *map[string]config.RPC) (ClientsI
 	return clientsInfo, nil
 }
 
-func GetChannelsInfo(ibc *relayer.IBCdata, rpcs *map[string]config.RPC) (ChannelsInfo, error) {
+func GetChannelsInfo(ibc *config.IBCData, rpcs *map[string]config.RPC) (ChannelsInfo, error) {
 	ctx := context.Background()
 	channelInfo := ChannelsInfo{}
 


### PR DESCRIPTION
This PR adds discord IDs to the metrics.
Also removes from one struct dependency from `gorelayer` to use `networks` repo schema instead.